### PR TITLE
Fix off-by-one error in Word2Vec `nearest()`

### DIFF
--- a/src/Word2vec/index.js
+++ b/src/Word2vec/index.js
@@ -48,7 +48,7 @@ class Word2Vec {
     if (!vector) {
       return null;
     }
-    return Word2Vec.nearest(this.model, vector, 1, max);
+    return Word2Vec.nearest(this.model, vector, 1, max + 1);
   }
 
   static addOrSubtract(model, values, operation) {


### PR DESCRIPTION
The `Word2Vec.nearest()` function, according to docs, accepts a `max`
parameter which is the maximum number of results returned. This commit
fixes a bug where calling the function with a `max` of 1 would return 0
results. The expected result would be 1 result. This is due to an `Array.slice()` call
that happens -- we were previously doing `nearestVectors.slice(start,max)` but since
`start` was hard-coded to 1 to remove the first result (always a trivial result), we were returning n-1 from the expected results. Internally  now we're doing `slice(1,max+1)`.