### PR TITLE
Fix bug when passing string to lstm.generate()

### DIFF
--- a/src/Lstm/index.js
+++ b/src/Lstm/index.js
@@ -67,8 +67,8 @@ class LSTMGenerator {
 
   async generate(options, callback) {
     const seed = options.seed || this.defaults.seed;
-    const length = options.length || this.defaults.length;
-    const temperature = options.temperature || this.defaults.temperature;
+    const length = +options.length || this.defaults.length;
+    const temperature = +options.temperature || this.defaults.temperature;
     const results = [];
 
     if (this.ready) {


### PR DESCRIPTION
This fixes a bug where if you pass the `length` and `temperature` options to `lstm.generate()` as a string (which is easy to do if you're using vanilla JS and not p5) you could end up with a situation where `generate()` would interpret `length` as a very large number and freeze up your CPU for a long time. Here I use the JS trick of prepending a "+" to a variable that could be either a String or a Number; this is a no-op on a Number but it casts a String to a Number, the equivalent of `Number(variable)`.