### PR TITLE
Add more verbose error to Word2vec.sum & average

### DIFF
--- a/src/Word2vec/index.js
+++ b/src/Word2vec/index.js
@@ -57,14 +57,14 @@ class Word2Vec {
     values.forEach((value) => {
       const vector = model[value];
       if (!vector) {
-        notFound.push(vector);
+        notFound.push(value);
       } else {
         vectors.push(vector);
       }
     });
 
     if (notFound.length > 0 || values.length < 2) {
-      return { error: 'Invalid inputs', notFound, values };
+      throw new Error(`Invalid input, vector not found for: ${notFound.toString()}`);
     }
     return ENV.math.scope(() => {
       let result = vectors[0];

--- a/src/Word2vec/index.js
+++ b/src/Word2vec/index.js
@@ -54,6 +54,9 @@ class Word2Vec {
   static addOrSubtract(model, values, operation) {
     const vectors = [];
     const notFound = [];
+    if (values.length < 2) {
+      throw new Error('Invalid input, must be passed more than 1 value');
+    }
     values.forEach((value) => {
       const vector = model[value];
       if (!vector) {
@@ -63,7 +66,7 @@ class Word2Vec {
       }
     });
 
-    if (notFound.length > 0 || values.length < 2) {
+    if (notFound.length > 0) {
       throw new Error(`Invalid input, vector not found for: ${notFound.toString()}`);
     }
     return ENV.math.scope(() => {


### PR DESCRIPTION
In issue #77 it's noted that Word2Vec throws an unhelpful error message
when you ask for the average of 2 words where one word isn't in the
dictionary. This can be traced to a less-than-helpful error message
thrown by `sum()`, which is called by `average()`.

This commit changes `sum()` to throw a "not found" `Error` object that
lists the words that were not found. This object propagates up to the
`average()` function.

The new output is:

```
> wordVectors.average(['blue','asdfgh'],1)
ml5.js:36063 Uncaught Error: Invalid input, vector not found for: asdfgh
    at Function.addOrSubtract (ml5.js:36063)
    at Word2Vec.average (ml5.js:36033)
    at <anonymous>:1:13
```

Additionally, it now catches if you try to average or sum a single value.