### PR TITLE
Documentation cleanup

### DIFF
--- a/docs/api-LSTM.md
+++ b/docs/api-LSTM.md
@@ -75,7 +75,7 @@ lstm.generate(options, function(output){
   ```javascript
   .generate(options, callback)
   ```
-  > Generates content base on the seed given. Returns ...
+  > Generates content based on the seed given. Returns ...
 
   `options` -  An object specifying the input parameters of seed, length and temperature. Defaults to `{ seed: 'a', length: 20, temperature: 0.5}`.
 

--- a/website/pages/en/experiments.js
+++ b/website/pages/en/experiments.js
@@ -20,44 +20,54 @@ class Help extends React.Component {
     // image is not working.
     const demos = [
       {
-        content: "Simple example base on Google's Teachable Machines Project",
+        content: "Simple example based on Google's Teachable Machines Project",
         image: siteConfig.baseUrl + "img/teachable.gif",
         title: 'Teachable Machines',
-        imageLink: "https://itpnyu.github.io/ml5/demos/teachableMachine",
-        imageAlign: "left"
+        link: "https://itpnyu.github.io/ml5/demos/teachableMachine",
       },
       {
         content: 'An experimental web text editor that runs a LSTM model while you write to suggest new lines',
         image: siteConfig.baseUrl + "img/selected_stories.gif",
         title: 'Selected Stories',
-        imageLink: "https://cvalenzuela.github.io/Selected_Stories/",
-        imageAlign: "left"
+        link: "https://cvalenzuela.github.io/Selected_Stories/",
       },
       {
         content: 'Machine Learning Pong Game in The Browser',
         image: siteConfig.baseUrl + "img/pongml.jpg",
         title: 'Pong ML',
-        imageLink: "https://github.com/matamalaortiz/Pong-ML",
-        imageAlign: "left"
+        link: "https://github.com/matamalaortiz/Pong-ML",
       },
       {
         content: 'Recomposing images in the style of other images',
         image: siteConfig.baseUrl + "img/style_transfer.gif",
         title: 'Fast Style Transfer',
-        imageLink: "https://yining1023.github.io/fast_style_transfer_in_ML5/",
-        imageAlign: "left"
+        link: "https://yining1023.github.io/fast_style_transfer_in_ML5/",
       },
     ];
+
+    let demoList = [];
+
+    for (let demo of demos) {
+      demoList.push(
+      <Container className="experiment flex-col">
+        <a href={demo.link}><h2>{demo.title}</h2></a>
+        <p>{demo.content}</p>
+        <a href={demo.link}><img src={demo.image} alt={demo.title}/></a>
+      </Container>
+      );
+    }
 
     return (
       <div className="docMainWrapper wrapper">
         <Container className="mainContainer documentContainer postContainer">
           <div className="post" id="experiments">
             <header className="postHeader">
-              <h2>Experiments</h2>
+              <h1>Experiments</h1>
             </header>
             <p>A collection of experiments and demos built with ML5.js.</p>
-            <GridBlock contents={demos} layout="twoColumn"/>
+            <div className="flex-grid">
+              {demoList}
+            </div>
           </div>
         </Container>
       </div>

--- a/website/pages/en/experiments.js
+++ b/website/pages/en/experiments.js
@@ -10,7 +10,6 @@ const React = require('react');
 const CompLibrary = require('../../core/CompLibrary.js');
 const MarkdownBlock = CompLibrary.MarkdownBlock;
 const Container = CompLibrary.Container;
-const GridBlock = CompLibrary.GridBlock;
 
 const siteConfig = require(process.cwd() + '/siteConfig.js');
 

--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -119,3 +119,34 @@ footer .sitemap h5 {
 footer iframe{
   margin: 20px 0px 0px 0px;
 }
+
+#experiments img {
+  max-width: 400px;
+  margin-top: 10px;
+}
+
+.experiment {
+  max-width: 500px;
+}
+
+/* Begin simple grid layout  */
+
+.flex-grid {
+  display: flex;
+  justify-content: left;
+  flex-wrap: wrap;
+}
+
+.flex-col {
+  flex: 1;
+  min-width: 400px;
+  padding: 14px;
+}
+
+@media only screen and (min-device-width : 320px) and (max-device-width : 480px) {
+  .flex-grid {
+    display: block;
+  }
+}
+
+/* End simple grid layout  */


### PR DESCRIPTION
This commit:

* Corrects some grammar errors in the docs
* Removes Docusaurus's `GridBlock` component from the Experiments page

`GridBlock` was designed for lists of features rather than as a generic grid class (it's uh, not really that well implemented either!). I have instead relied on a very small custom grid class that uses `display: flex` to do a simple grid layout. The layout works well on all screen formats I tested and just generally looks a lot better.

Here's an example of the change in layout.

Old version:

![image](https://user-images.githubusercontent.com/266454/36912506-e2ea148e-1e14-11e8-9e4f-98af2b54e0a4.png)

New version:

![image](https://user-images.githubusercontent.com/266454/36912520-ef71292c-1e14-11e8-9f8f-89a43110b16a.png)

And on mobile...

Old version (notice that preview images currently don't even render!):

![image](https://user-images.githubusercontent.com/266454/36912588-1f8ddf74-1e15-11e8-9f9f-a3d00357387f.png)

New version:

![image](https://user-images.githubusercontent.com/266454/36912601-2d8d2102-1e15-11e8-8a44-bab956fda843.png)
